### PR TITLE
Challenge Deployment verify now all DNS-Servers before finishing deployment

### DIFF
--- a/pdns.sh
+++ b/pdns.sh
@@ -50,7 +50,7 @@ if [[ "$1" = "deploy_challenge" ]]; then
   # get nameservers for domain
   nameservers="$(dig -t ns +short ${domain#*.})"
   while :
-    do  
+    do
         failed_servers=0
         for nameserver in $nameservers;do
                 if ! dig @$nameserver +short -t TXT _acme-challenge.$domain | grep -- "$token" > /dev/null
@@ -58,13 +58,12 @@ if [[ "$1" = "deploy_challenge" ]]; then
                         failed_servers=1
                 fi
         done
-	# return only if every server has the challenge
+        # return only if every server has the challenge
         [ "$failed_servers" == 0 ] && break
         sleep 1
        printf "."
     done
    done="yes"
-   sleep 30
 fi
 
 if [[ "$1" = "clean_challenge" ]]; then

--- a/pdns.sh
+++ b/pdns.sh
@@ -53,6 +53,7 @@ if [[ "$1" = "deploy_challenge" ]]; then
        sleep 3
     done
    done="yes"
+   sleep 30
 fi
 
 if [[ "$1" = "clean_challenge" ]]; then


### PR DESCRIPTION
Added code to check all nameservers of the domain. I'm not sure if it is only at my site, that replication to the slave servers is not in realtime. This change makes it sure that all servers are answering correct to the challenge. ( I figured out several fails were caused by my second dns, which did not have the challenge when asked by the registry servers. )

The other commits were reverted. Waiting time is not necessary.
